### PR TITLE
Mark DataPacks as references in callback definitions

### DIFF
--- a/scripting/include/gameme.inc
+++ b/scripting/include/gameme.inc
@@ -44,7 +44,7 @@ forward onGameMEStatsPublicCommand(command, client, String: message_prefix[], &H
 forward onGameMEStatsTop10(command, client, String: message_prefix[], &Handle: datapack);
 forward onGameMEStatsNext(command, client, String: message_prefix[], &Handle: datapack);
 
-typedef gameMEStatsCallback = function Action(int command, int payload, int client, Handle datapack);
+typedef gameMEStatsCallback = function Action(int command, int payload, int client, Handle &datapack);
 /**
  * Query gameME Stats data from a client
  * 
@@ -57,7 +57,7 @@ typedef gameMEStatsCallback = function Action(int command, int payload, int clie
 native QueryGameMEStats(String: request[], client, gameMEStatsCallback: callback, payload = 0);
 
 
-typedef gameMEStatsTop10Callback = function Action(int command, int payload, Handle datapack);
+typedef gameMEStatsTop10Callback = function Action(int command, int payload, Handle &datapack);
 /**
  * Query Top10 players from gameME Stats
  * 
@@ -70,7 +70,7 @@ typedef gameMEStatsTop10Callback = function Action(int command, int payload, Han
 native QueryGameMEStatsTop10(String: request[], client, gameMEStatsTop10Callback: callback, payload = 0);
 
 
-typedef gameMEStatsNextCallback = function Action(int command, int payload, int client, Handle datapack);
+typedef gameMEStatsNextCallback = function Action(int command, int payload, int client, Handle &datapack);
 /**
  * Query next players from gameME Stats for s specified client
  * 


### PR DESCRIPTION
In 98f1126fbebd8c02a0c45a8c2f21e562f4e9b832 the callback definitions were updated to transitional syntax. However, the ampersand indicating the DataPacks are passed by reference was dropped (I assume accidentally).

In their current state, no plugins are able to use these natives as you'll receive an error when trying to manipulate the Handle:
```
L 01/04/2021 - 02:17:16: [SM] Exception reported: Handle 18f8 cannot be cloned because it is invalid (error 4)
L 01/04/2021 - 02:17:16: [SM] Blaming: plugin.smx
L 01/04/2021 - 02:17:16: [SM] Call stack trace:
L 01/04/2021 - 02:17:16: [SM]   [0] CloneHandle
L 01/04/2021 - 02:17:16: [SM]   [1] Line 221, plugin.sp::QueryGameMEStatsReceived
L 01/04/2021 - 02:17:16: [SM]   [3] Call_Finish
L 01/04/2021 - 02:17:16: [SM]   [4] Line 4076, gameme.sp::gameme_raw_messag
```

This happens because the Handle is pushed with `Call_PushCellRef` rather than `Call_PushCell`, therefore requiring the prepended ampersand:
https://github.com/gamemedev/plugin-sourcemod/blob/98f1126fbebd8c02a0c45a8c2f21e562f4e9b832/scripting/gameme.sp#L3888-L3895
